### PR TITLE
Feature: Extended developer API to include revenue by all completed contracts for a specific developer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/domain/developers/errors.ts
+++ b/src/domain/developers/errors.ts
@@ -1,0 +1,5 @@
+export const DeveloperByIdNotFoundError = {
+    statusCode: 404,
+    name: 'Developer not found',
+    message: 'Developer with requested id is not found'
+}

--- a/src/domain/developers/repositories/data.ts
+++ b/src/domain/developers/repositories/data.ts
@@ -1,14 +1,14 @@
-import { IDeveloper } from '../types'
+import { IContract, IDeveloper, ContractStatus } from '../types'
 
-export const contracts = [
-	{ id: 1, developerId: '65de3467255f31cb84bd071d', status: 'pending', amount: 5000 },
-	{ id: 2, developerId: '65de346c255f31cb84bd10e9', status: 'completed', amount: 12000 },
-	{ id: 3, developerId: '65de346c255f31cb84bd10e9', status: 'ongoing', amount: 200 },
-	{ id: 4, developerId: '65de346b255f31cb84bd0fd6', status: 'pending', amount: 500 },
-	{ id: 5, developerId: '65de346a255f31cb84bd0e01', status: 'completed', amount: 6000 },
-	{ id: 6, developerId: '65de346a255f31cb84bd0e01', status: 'completed', amount: 5000 },
-	{ id: 7, developerId: '65de3467255f31cb84bd071d', status: 'ongoing', amount: 8000 },
-	{ id: 8, developerId: '65de3467255f31cb84bd071d', status: 'ongoing', amount: 32000 },
+export const contracts: IContract[] = [
+	{ id: 1, developerId: '65de3467255f31cb84bd071d', status: ContractStatus.pending, amount: 5000 },
+	{ id: 2, developerId: '65de346c255f31cb84bd10e9', status: ContractStatus.completed, amount: 12000 },
+	{ id: 3, developerId: '65de346c255f31cb84bd10e9', status: ContractStatus.ongoing, amount: 200 },
+	{ id: 4, developerId: '65de346b255f31cb84bd0fd6', status: ContractStatus.pending, amount: 500 },
+	{ id: 5, developerId: '65de346a255f31cb84bd0e01', status: ContractStatus.completed, amount: 6000 },
+	{ id: 6, developerId: '65de346a255f31cb84bd0e01', status: ContractStatus.completed, amount: 5000 },
+	{ id: 7, developerId: '65de3467255f31cb84bd071d', status: ContractStatus.ongoing, amount: 8000 },
+	{ id: 8, developerId: '65de3467255f31cb84bd071d', status: ContractStatus.ongoing, amount: 32000 },
 ]
 
 export const developers: IDeveloper[] = [

--- a/src/domain/developers/services/developers.service.ts
+++ b/src/domain/developers/services/developers.service.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { DevelopersRepository } from '../repositories/developers.repository';
-import { IDeveloper } from '../types'
+import {  IDeveloperWithRevenue } from '../types'
 
 @injectable()
 export class DevelopersService {
@@ -9,12 +9,11 @@ export class DevelopersService {
 		@inject('DevelopersRepository') private developersRepository: DevelopersRepository,
 	) {}
 
-	async getDevelopers(): Promise<IDeveloper[]>{
+	async getDevelopers(): Promise<IDeveloperWithRevenue[]>{
 		return this.developersRepository.getDevelopers()
 	}
 
-	async getDeveloperById(id: string){
+	async getDeveloperById(id: string): Promise<IDeveloperWithRevenue>{
 		return this.developersRepository.getDeveloperById(id)
 	}
-
 }

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -1,10 +1,30 @@
 export interface IDeveloper {
-
 	id: string
 
 	firstName?: string
 	lastName?: string
 
 	email: string
+}
 
+export interface IDeveloperWithRevenue extends IDeveloper {
+	revenue: number
+}
+
+export enum ContractStatus {
+	pending = 'pending',
+	completed = 'completed',
+	ongoing = 'ongoing'
+}
+
+type Status = ContractStatus.pending | ContractStatus.completed | ContractStatus.ongoing
+
+export interface IContract {
+	id: number
+
+	developerId: string
+
+	status: Status
+
+	amount: number
 }

--- a/src/rest/dto/developers.responses.dto.ts
+++ b/src/rest/dto/developers.responses.dto.ts
@@ -1,8 +1,8 @@
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts'
-import { IDeveloper } from '../../domain/developers/types'
+import { IDeveloperWithRevenue } from '../../domain/developers/types'
 
 @ApiModel()
-export class DeveloperDto implements IDeveloper {
+export class DeveloperDto implements IDeveloperWithRevenue {
 
 	@ApiModelProperty()
 	id: string
@@ -16,5 +16,6 @@ export class DeveloperDto implements IDeveloper {
 	@ApiModelProperty()
 	email: string
 
-
+	@ApiModelProperty()
+	revenue: number
 }

--- a/test/developers.test.ts
+++ b/test/developers.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 import { request } from './setup/shortcuts'
 import { createRequestWithContainerOverrides } from './setup/helpers'
 import { DevelopersRepository } from '../src/domain/developers/repositories/developers.repository'
+import { GetDeveloperByIdMockResponse, GetDevelopersMockResponse } from './setup/mockData'
 
 describe('Developers API tests examples', () => {
 
@@ -17,35 +18,77 @@ describe('Developers API tests examples', () => {
 			expect(developer).toHaveProperty('firstName')
 			expect(developer).toHaveProperty('lastName')
 			expect(developer).toHaveProperty('email')
+			expect(developer).toHaveProperty('revenue')
 		}
-
 	})
+
+	it('should BAT fetch developer by id (e2e, real repository used)', async () => {
+
+		const result = await request.get(`/api/developers/65de346c255f31cb84bd10e9`)
+		const developer = result.body
+
+		expect(result.status).toBe(200)
+		expect(developer).toHaveProperty('id')
+		expect(developer).toHaveProperty('firstName')
+		expect(developer).toHaveProperty('lastName')
+		expect(developer).toHaveProperty('email')
+		expect(developer).toHaveProperty('revenue')
+		expect(developer.revenue).toBe(12000)
+	})
+
+	it('should return error when developer is not found by provided id (e2e, real repository used)', async () => {
+
+		const result = await request.get(`/api/developers/qweqwe`)
+
+		expect(result.status).toBe(404)
+		expect(result.text).toBe("{\"error\":{\"name\":\"Developer not found\",\"message\":\"Developer with requested id is not found\"}}")
+	})
+
+	it('should BAT get developers (mocked repository used)', async () => {
+
+		const req = await createRequestWithContainerOverrides({
+			'DevelopersRepository': {
+				toConstantValue: {
+					getDevelopers: async (_id) => (GetDevelopersMockResponse)
+				} as Partial<DevelopersRepository>
+			}
+		})
+
+		const result = await req.get(`/api/developers`)
+
+		expect(result.status).toBe(200)
+		expect(result.body?.length).toBeGreaterThan(0)
+
+		for( const developer of result.body ){
+			expect(developer).toHaveProperty('id')
+			expect(developer).toHaveProperty('firstName')
+			expect(developer).toHaveProperty('lastName')
+			expect(developer).toHaveProperty('email')
+			expect(developer).toHaveProperty('revenue')
+		}
+	})
+
 
 	it('should BAT get developer by id (mocked repository used)', async () => {
 
 		const req = await createRequestWithContainerOverrides({
 			'DevelopersRepository': {
 				toConstantValue: {
-					getDeveloperById: async (_id) => ({
-						"id": "65de346c255f31cb84bd10e9",
-						"email": "Brandon30@hotmail.com",
-						"firstName": "Brandon",
-						"lastName": "D'Amore"
-					})
+					getDeveloperById: async (_id) => (GetDeveloperByIdMockResponse)
 				} as Partial<DevelopersRepository>
 			}
 		})
 
 		const result = await req.get(`/api/developers/65de346c255f31cb84bd10e9`)
+		const developer = result.body
 
 		expect(result.status).toBe(200)
-
-		const developer = result.body
 		expect(developer).toHaveProperty('id')
 		expect(developer).toHaveProperty('firstName')
 		expect(developer).toHaveProperty('lastName')
 		expect(developer).toHaveProperty('email')
-
+		expect(developer).toHaveProperty('revenue')
+		expect(developer.revenue).toBe(12000)
 	})
 
 })

--- a/test/setup/mockData.ts
+++ b/test/setup/mockData.ts
@@ -1,0 +1,24 @@
+export const GetDeveloperByIdMockResponse = {
+    "id": "65de346c255f31cb84bd10e9",
+    "email": "Brandon30@hotmail.com",
+    "firstName": "Brandon",
+    "lastName": "D'Amore",
+    "revenue": 12000,
+}
+
+export const GetDevelopersMockResponse = [
+    {
+        "id": "65de346c255f31cb84bd10e9",
+        "email": "Brandon30@hotmail.com",
+        "firstName": "Brandon",
+        "lastName": "D'Amore",
+        "revenue": 12000,
+    },
+    {
+        "id": "65de3467255f31cb84bd07c2",
+		"email": "Makenna.Hand@yahoo.com",
+		"firstName": "Makenna",
+		"lastName": "Hand",
+        "revenue": 0,
+    }
+]


### PR DESCRIPTION
This PR introduces changes to developer API to include revenue from all completed contracts for a specific developer in the response.

Changes:
- Extended developer api to include revenue by all completed contracts for a specific developer
- Added tests
- Added additional error handling
- Added types

P.S.: Originally I've implemented this patch in one commit, but I have decided to split it into smaller separate commits for better readability.